### PR TITLE
Prevent overgenerous prefix match

### DIFF
--- a/lib/abtest/asset.rb
+++ b/lib/abtest/asset.rb
@@ -24,7 +24,7 @@ module Sprockets
           # Check to see if we are in an experiment
           if (path.starts_with?("experiments"))
             Abtest.abtest_config.registered_tests.each do |test_hash|
-              if (path.starts_with?("experiments/#{test_hash[:name]}"))
+              if (path.starts_with?("experiments/#{test_hash[:name]}/"))
                 # Strip experiment path
                 experiment_path = path.sub("experiments/#{test_hash[:name]}/", '')
 


### PR DESCRIPTION
Without this, if you have 2 tests with shared prefix, like test and test, test2 will always search for assets in the first test's path
